### PR TITLE
Allow conditions to be force on the cli #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ By default all experiments start disabled, so you can't accidentally apply broke
 
 Once an experiment is enabled, it can also be enabled for admin accounts as well, which are ignored by the plugin by default. This option should be used with care, as bad configuration may result in all administrator accounts being locked out from the moodle instance, in extreme cases. In the event that something goes wrong when applying experiments to admins as well, the URL parameter `?abconfig=off` can be used to ignore the plugin entirely for that page, which can be used to regain access.
 
+You can also force conditions in the same var by setting an environment variable. If the experiment was called 'setconfig' and the conditionset was called 'passwordpolicy' then this would force it on in the cli:
+
+```sh
+ABCONFIG_SETCONFIG=passwordpolicy php admin/cli/cfg.php --name=themelist
+```
+
 Example use cases
 -----------------
 

--- a/lib.php
+++ b/lib.php
@@ -40,22 +40,29 @@ function tool_abconfig_after_config() {
 
         // Get all experiments.
         $experiments = $manager->get_experiments();
-        // Check URL params, and fire any experiments in the params.
         foreach ($experiments as $experiment => $contents) {
-            $conditionparam = optional_param($experiment, null, PARAM_TEXT);
 
-            // Only admins can fire additional experiments.
-            if (!is_siteadmin()) {
-                break;
+            if (defined('CLI_SCRIPT') && CLI_SCRIPT) {
+                // Check ENV vars set on the cli.
+                $condition = getenv('ABCONFIG_' . strtoupper($experiment));
+            } else {
+
+                // Check URL params, and fire any experiments in the params.
+                $condition = optional_param($experiment, null, PARAM_TEXT);
+
+                // Only admins can fire additional experiments.
+                if (!is_siteadmin()) {
+                    break;
+                }
             }
 
-            if (empty($conditionparam)) {
+            if (empty($condition)) {
                 continue;
             }
 
             // Ensure condition set exists before executing.
-            if (array_key_exists($conditionparam, $contents['conditions'])) {
-                tool_abconfig_execute_command_array($contents['conditions'][$conditionparam]['commands'],
+            if (array_key_exists($condition, $contents['conditions'])) {
+                tool_abconfig_execute_command_array($contents['conditions'][$condition]['commands'],
                     $contents['shortname']);
             }
         }


### PR DESCRIPTION
To set:

```
php admin/cli/cfg.php --name=themelist
(not set)
```
Make an experiment called setconfig with a conditionset called passwordpolicy with 

["CFG,themelist,duck"] | 100
-- | --

```
root@110310e34473:/var/www/master# php admin/cli/cfg.php --name=themelist

root@110310e34473:/var/www/master# setconfig=passwordpolicy php admin/cli/cfg.php --name=themelist
duck
```


Resolves #50 
