### PR TITLE
Add device experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,17 @@ Here is where the commands for a condition set can be specified. These are appli
 This command sets moodle core configurations to a specified value.
 
 Note: `CFG` and `forced_plugin_setting` commands will not overwrite config set inside config.php by design as a security measure.
+However you can allow this by setting:
+
+```php
+$CFG->somethingforced = 'original value';
+$CFG->somethingforced_allow_abconfig = 1;
+```
 
 ```
 CFG,config,value
 CFG,passwordpolicy,1
+CFG,somethingforced,myoverride
 ```
 
 ##### forced_plugin_setting

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuration
 Visit the Site Administration menu and navigate to Plugins->Admin Tools->Manage Experiments. This page allows you to add new experiments, as well as edit existing experiments. To add a new experiment, fill in the fields, and click 'Add Experiment'. To edit the details of an existing experiment, click on the Edit link inside of the experiments table, to go to the edit page.
 
 ### Scopes and audiences
-The plugin currently has two scopes that experiments can lie under, Request scope and Session scope.
+The plugin currently has three scopes that experiments can lie under, Request scope, Session scope and Device scope.
 
 #### Request scope
 
@@ -48,6 +48,10 @@ Request scope experiments are run on every http request. Any request scope will 
 #### Session scope
 
 Session scope experiments are called when a user logs into the site. At this time, a condition set will be decided on, and users will continue to have that condition set applied for the length of their session. This does not apply to guest users, only logged in users. When a user logs out, and logs back in, a new set of conditions is applied to the account, which may be the same condition set.
+
+#### Device scope
+
+Device scope experiments are set up before a session starts. This will set conditions for users based on their ip address and user agent. This scope allows conditions to be set earlier in the start up process, but it can only target a percentage of traffic and not specific users.
 
 ### Conditions
 

--- a/classes/form/edit_conditions.php
+++ b/classes/form/edit_conditions.php
@@ -57,6 +57,8 @@ class edit_conditions extends \moodleform {
 
         // Get Data for repeating elements.
         $manager = new \tool_abconfig_experiment_manager();
+        $experiment = $manager->get_experiment($eid);
+        $scope = $experiment->scope ?? '';
         $records = $manager->get_conditions_for_experiment($eid);
         $setcount = 1;
         foreach ($records as $record) {
@@ -92,6 +94,10 @@ class edit_conditions extends \moodleform {
             $mform->setType("users{$id}", PARAM_TEXT);
             if (!empty($record->users)) {
                 $mform->setDefault("users{$id}", json_decode($record->users));
+            }
+            // Hide user section if they can't be used.
+            if ($scope === 'device') {
+                $mform->hideIf("users{$id}", 'eid', 'neq', 0);
             }
 
             // Commands.

--- a/classes/form/edit_experiment.php
+++ b/classes/form/edit_experiment.php
@@ -66,14 +66,26 @@ class edit_experiment extends \moodleform {
         $mform->addRule('experimentshortname', get_string('formexperimentshortnamereq', 'tool_abconfig'), 'required');
 
         // Setup Data array for scopes.
-        $scopes = ['request' => get_string('request', 'tool_abconfig'), 'session' => get_string('session', 'tool_abconfig')];
+        $scopes = [
+            'request' => get_string('request', 'tool_abconfig'),
+            'session' => get_string('session', 'tool_abconfig'),
+            'device' => get_string('device', 'tool_abconfig'),
+        ];
         $mform->addElement('select', 'scope', get_string('formexperimentscopeselect', 'tool_abconfig'), $scopes);
+
+        $mform->addElement('text', 'numoffset', get_string('offset', 'tool_abconfig'));
+        $mform->setType('numoffset', PARAM_INT);
+        $mform->hideIf('numoffset', 'scope', 'neq', 'device');
+        $mform->addRule('numoffset', get_string('err_numeric', 'form'), 'numeric', null, 'client');
+        $mform->addRule('numoffset', get_string('maximumchars', '', 2), 'maxlength', 2, 'client');
+        $mform->addHelpButton('numoffset', 'offset', 'tool_abconfig');
 
         // Enabled checkbox.
         $mform->addElement('advcheckbox', 'enabled', get_string('formexperimentenabled', 'tool_abconfig'));
 
         // Admin Enabled Checkbox.
         $mform->addElement('advcheckbox', 'adminenabled', '', get_string('formexperimentadminenable', 'tool_abconfig'));
+        $mform->hideIf('adminenabled', 'scope', 'eq', 'device');
 
         // Delete experiment checkbox.
         $mform->addElement('advcheckbox', 'delete', get_string('formdeleteexperiment', 'tool_abconfig'));

--- a/classes/form/manage_experiments.php
+++ b/classes/form/manage_experiments.php
@@ -46,7 +46,11 @@ class manage_experiments extends \moodleform {
         $mform = $this->_form;
 
         // Setup Data array for scopes.
-        $scopes = ['request' => get_string('request', 'tool_abconfig'), 'session' => get_string('session', 'tool_abconfig')];
+        $scopes = [
+            'request' => get_string('request', 'tool_abconfig'),
+            'session' => get_string('session', 'tool_abconfig'),
+            'device' => get_string('device', 'tool_abconfig'),
+        ];
 
         // Add section for adding experiments.
         $mform->addElement('header', 'addexperiment', get_string('formaddexperiment', 'tool_abconfig'));

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/abconfig/db" VERSION="20190920" COMMENT="XMLDB file for Moodle admin/tool/abconfig"
+<XMLDB PATH="admin/tool/abconfig/db" VERSION="20250113" COMMENT="XMLDB file for Moodle admin/tool/abconfig"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -12,6 +12,7 @@
         <FIELD NAME="scope" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="enabled" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Bool flag for whether the experiment is enabled or disabled"/>
         <FIELD NAME="adminenabled" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Field to track whether this experiment is enabled for admins"/>
+        <FIELD NAME="numoffset" TYPE="int" LENGTH="5" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -45,5 +45,20 @@ function xmldb_tool_abconfig_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022070600, 'tool', 'abconfig');
     }
 
+    if ($oldversion < 2025011300) {
+
+        // Define field numoffset to be added to tool_abconfig_experiment.
+        $table = new xmldb_table('tool_abconfig_experiment');
+        $field = new xmldb_field('numoffset', XMLDB_TYPE_INTEGER, '5', null, null, null, null, 'adminenabled');
+
+        // Conditionally launch add field numoffset.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Abconfig savepoint reached.
+        upgrade_plugin_savepoint(true, 2025011300, 'tool', 'abconfig');
+    }
+
     return true;
 }

--- a/edit_experiment.php
+++ b/edit_experiment.php
@@ -49,7 +49,8 @@ $manager = new tool_abconfig_experiment_manager();
 $experiment = $DB->get_record('tool_abconfig_experiment', array('id' => $eid));
 $data = array('experimentname' => $experiment->name, 'experimentshortname' => $experiment->shortname,
     'prevshortname' => $experiment->shortname, 'scope' => $experiment->scope,
-    'id' => $experiment->id, 'enabled' => $experiment->enabled, 'adminenabled' => $experiment->adminenabled);
+    'id' => $experiment->id, 'enabled' => $experiment->enabled, 'adminenabled' => $experiment->adminenabled,
+    'numoffset' => $experiment->numoffset ?? rand(0, 99));
 
 $customarray = array('eid' => $experiment->id);
 
@@ -72,6 +73,7 @@ if ($form->is_cancelled()) {
     $eid = $fromform->id;
     $prevshortname = $fromform->prevshortname;
     $adminenabled = $fromform->adminenabled;
+    $numoffset = $fromform->numoffset;
 
     // If eid is empty, do nothing.
     if ($eid == 0) {
@@ -83,7 +85,7 @@ if ($form->is_cancelled()) {
         $manager->delete_experiment($shortname);
         $manager->delete_all_conditions($eid);
     } else {
-        $manager->update_experiment($prevshortname, $name, $shortname, $scope, $enabled, $adminenabled);
+        $manager->update_experiment($prevshortname, $name, $shortname, $scope, $enabled, $adminenabled, $numoffset);
     }
 
     redirect($prevurl);

--- a/lang/en/tool_abconfig.php
+++ b/lang/en/tool_abconfig.php
@@ -65,9 +65,12 @@ $string['formexperimentadminenable'] = 'Enable this experiment for site admins.'
 // Short Strings.
 $string['request'] = 'Request';
 $string['session'] = 'Session';
+$string['device'] = 'Device';
 $string['name'] = 'Experiment name';
 $string['shortname'] = 'Short experiment name';
 $string['scope'] = 'Experiment scope';
+$string['offset'] = 'Offset';
+$string['offset_help'] = 'Offset value between 0 and 99 that will be used to rotate device hashes.';
 $string['edit'] = 'Edit';
 $string['enabled'] = 'Enabled';
 $string['yes'] = 'Yes';

--- a/lib.php
+++ b/lib.php
@@ -33,8 +33,10 @@ defined('MOODLE_INTERNAL') || die;
  * @return void|null
  */
 function tool_abconfig_after_config() {
+
+    global $SESSION, $USER, $CFG;
+
     try {
-        global $SESSION, $USER;
 
         // Setup experiment manager.
         $manager = new tool_abconfig_experiment_manager();
@@ -269,10 +271,15 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
         if ($command == 'CFG') {
             $commandarray = explode(',', $commandstring, 3);
 
-            // Ensure that command hasnt already been set in config.php.
-            if (!array_key_exists($commandarray[1], $CFG->config_php_settings)) {
+            // Allow override if set in config.php already:
+            $allow = isset($CFG->{$commandarray[1] . '_allow_abconfig'});
+
+            // Ensure that command hasn't already been set in config.php.
+            if ($allow || !array_key_exists($commandarray[1], $CFG->config_php_settings)) {
                 $CFG->{$commandarray[1]} = $commandarray[2];
                 $CFG->config_php_settings[$commandarray[1]] = $commandarray[2];
+            } else {
+                error_log("abconfig: Can't override \$CFG->{$commandarray[1]} because already set in config.php!");
             }
         }
         if ($command == 'forced_plugin_setting') {

--- a/lib.php
+++ b/lib.php
@@ -349,7 +349,7 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
         if ($command == 'CFG') {
             $commandarray = explode(',', $commandstring, 3);
 
-            // Allow override if set in config.php already:
+            // Allow override if set in config.php already.
             $allow = isset($CFG->{$commandarray[1] . '_allow_abconfig'});
 
             // Ensure that command hasn't already been set in config.php.
@@ -357,6 +357,8 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
                 $CFG->{$commandarray[1]} = $commandarray[2];
                 $CFG->config_php_settings[$commandarray[1]] = $commandarray[2];
             } else {
+                // Debugging shouldn't be used before sessions are loaded.
+                // @codingStandardsIgnoreLine
                 error_log("abconfig: Can't override \$CFG->{$commandarray[1]} because already set in config.php!");
             }
         }
@@ -364,12 +366,18 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
             // Check for plugin commands.
             $commandarray = explode(',', $commandstring, 4);
 
-            // Ensure that command hasnt already been forced in config.php.
-            // If plugin settings array doesnt exist, or the actualy config key doesnt exist.
+            // Ensure that command hasnt already been forced in config.php or that overriding is allowed.
+            // If plugin settings array doesnt exist, or the actual config key doesnt exist.
             if (!array_key_exists($commandarray[1], $CFG->forced_plugin_settings) ||
-                !array_key_exists($commandarray[2], $CFG->forced_plugin_settings[$commandarray[1]])) {
+                    !array_key_exists($commandarray[2], $CFG->forced_plugin_settings[$commandarray[1]]) ||
+                    array_key_exists($commandarray[2] . '_allow_abconfig', $CFG->forced_plugin_settings[$commandarray[1]])) {
 
                 $CFG->forced_plugin_settings[$commandarray[1]][$commandarray[2]] = $commandarray[3];
+            } else {
+                // Debugging shouldn't be used before sessions are loaded.
+                // @codingStandardsIgnoreLine
+                error_log("abconfig: Can't override \$CFG->forced_plugin_settings['$commandarray[1]']['$commandarray[2]'] " .
+                    "because already set in config.php!");
             }
         }
         if ($command == 'http_header') {

--- a/tests/experiment_manager_test.php
+++ b/tests/experiment_manager_test.php
@@ -85,7 +85,7 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
             array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
 
         // Update all the values of the experiment.
-        $manager->update_experiment('shortname', 'name2', 'shortname2', 'session', 1, 1);
+        $manager->update_experiment('shortname', 'name2', 'shortname2', 'session', 1, 1, 33);
 
         // Get record and verify fields.
         $sqlexperiment = $DB->sql_compare_text('shortname2', strlen('shortname2'));
@@ -96,6 +96,7 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertEquals($record->scope, 'session');
         $this->assertEquals($record->enabled, 1);
         $this->assertEquals($record->adminenabled, 1);
+        $this->assertEquals($record->numoffset, 33);
     }
 
     public function test_delete_experiment() {

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -31,7 +31,7 @@ require_once(__DIR__.'/../lib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_abconfig_lib_testcase extends advanced_testcase {
+class tool_abconfig_lib_test extends advanced_testcase {
 
     public function test_request_no_experiment() {
         $this->resetAfterTest(true);

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024060404;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024060404;      // Same as version.
+$plugin->version   = 2025011300;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2025011300;      // Same as version.
 $plugin->requires  = 2014051217;
 $plugin->supported = [38, 405];       // Available as of Moodle 3.8.0 or later.
 $plugin->component = "tool_abconfig";

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024060403;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024060403;      // Same as version.
+$plugin->version   = 2024060404;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024060404;      // Same as version.
 $plugin->requires  = 2014051217;
 $plugin->supported = [38, 405];       // Available as of Moodle 3.8.0 or later.
 $plugin->component = "tool_abconfig";


### PR DESCRIPTION
Closes #75 
Closes #74 - Rather than converting everything to _before_session and trying to resolve other issues with $SESSION and $USER being null, it's safer to only have the new experiment type use it.

- Re-add allow override of config.php from #76 without the problematic _before_session changes
- Adds new 'device' experiment type that uses _before_session
- Moves js render logic from SESSION to a static variable in manager