### PR TITLE
Allow param previews of device experiments #81

### DIFF
--- a/classes/experiment_manager.php
+++ b/classes/experiment_manager.php
@@ -293,6 +293,40 @@ class tool_abconfig_experiment_manager {
     }
 
     /**
+     * Get all experiments that should be run before session
+     * @return mixed
+     */
+    public function get_before_session_experiments() {
+        $experiments = self::get_experiments();
+
+        // Filter array for all before session experiments.
+        return array_filter($experiments, function ($experiment) {
+            if ($experiment['scope'] == 'device') {
+                return true;
+            } else {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Get all experiments that should be run after config
+     * @return mixed
+     */
+    public function get_after_config_experiments() {
+        $experiments = self::get_experiments();
+
+        // Filter array for all after config experiments.
+        return array_filter($experiments, function ($experiment) {
+            if (in_array($experiment['scope'], ['request', 'session'])) {
+                return true;
+            } else {
+                return false;
+            }
+        });
+    }
+
+    /**
      * Get active requests
      * @return mixed
      */
@@ -333,7 +367,7 @@ class tool_abconfig_experiment_manager {
     public function get_active_device() {
         $experiments = self::get_experiments();
 
-        // Filter array for only enabled session experiments.
+        // Filter array for only enabled device experiments.
         return array_filter($experiments, function ($experiment) {
             if ($experiment['enabled'] == 1 && $experiment['scope'] == 'device') {
                 return true;

--- a/lib.php
+++ b/lib.php
@@ -48,8 +48,8 @@ function tool_abconfig_after_config() {
             }
         }
 
-        // Get all experiments.
-        $experiments = $manager->get_experiments();
+        // Get all after congig experiments and check params.
+        $experiments = $manager->get_after_config_experiments();
         foreach ($experiments as $experiment => $contents) {
 
             if (defined('CLI_SCRIPT') && CLI_SCRIPT) {
@@ -172,6 +172,23 @@ function tool_abconfig_before_session_start() {
 
         // Setup experiment manager.
         $manager = new tool_abconfig_experiment_manager();
+
+        // Get all before session experiments and check params.
+        $experiments = $manager->get_before_session_experiments();
+        foreach ($experiments as $experiment => $contents) {
+
+            // Check URL params, and fire any experiments in the params.
+            $condition = optional_param($experiment, null, PARAM_TEXT);
+            if (empty($condition)) {
+                continue;
+            }
+
+            // Ensure condition set exists before executing.
+            if (array_key_exists($condition, $contents['conditions'])) {
+                tool_abconfig_execute_command_array($contents['conditions'][$condition]['commands'],
+                    $contents['shortname']);
+            }
+        }
 
         // First, Build a list of all commands that need to be executed.
         $commandarray = [];


### PR DESCRIPTION
Getting the param to work properly is the simplest approach to achieve the desired outcome.

This can't be restricted to admins like after config experiments, but there should still be enough obscurity with the param names, and even if they are known the impact should be limited.

Showing a temporary preview after saving but before confirming may be possible with this param, but it feels overkill and would likely run into issues with the implementation. 

Closes #81 