### PR TITLE
Fix reset logic in unit test

### DIFF
--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -132,6 +132,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Manually set config back to false, then call hook again, and test.
         // Simulates next page load.
+        unset($CFG->forced_plugin_settings['auth_manual']['expiration']);
         set_config('expiration', 'no', 'auth_manual');
         tool_abconfig_after_config();
         $this->assertEquals(get_config('auth_manual', 'expiration'), 'yes');


### PR DESCRIPTION
Following the addition of error log output when trying to override forced plugin settings, test_request_plugin_experiment is sending the following to the error log:

`abconfig: Can't override $CFG->forced_plugin_settings['auth_manual']['expiration'] because already set in config.php!`

This is because the forced config isn't being properly reset when simulating the next page load, like it is elsewhere in the tests.