### PR TITLE
Add previous version check to exit from after_config blocking state

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -65,7 +65,7 @@ class hook_callbacks {
     public static function after_config(\core\hook\after_config $hook) {
         global $CFG;
 
-        if (during_initial_install() || isset($CFG->upgraderunning)) {
+        if (during_initial_install() || isset($CFG->upgraderunning) || !get_config('tool_abconfig', 'version')) {
             return;
         }
 


### PR DESCRIPTION
I have added back a part of what have been removed here https://github.com/catalyst/moodle-tool_abconfig/commit/ea019448942bd510ec82a5cb37213dba6e8cb864#diff-56dc33dbcb74a2a47dce9b841a250b427c7f46fb2e0e5495ea8a3afbcf7d9e38L64