### PR TITLE
[#92] Fix sql comparison in mssql

### DIFF
--- a/classes/experiment_manager.php
+++ b/classes/experiment_manager.php
@@ -84,13 +84,9 @@ class tool_abconfig_experiment_manager {
      */
     public function experiment_exists($shortname) {
         global $DB;
-        $sqlexperiment = $DB->sql_compare_text($shortname, strlen($shortname));
-        $record = $DB->get_record_sql('SELECT * FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlexperiment));
-        if (empty($record)) {
-            return false;
-        } else {
-            return true;
-        }
+        $sql = 'SELECT * FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+        $record = $DB->get_record_sql($sql, ['shortname' => $shortname]);
+        return !empty($record);
     }
 
     /**
@@ -111,8 +107,8 @@ class tool_abconfig_experiment_manager {
             $return = false;
         } else {
             // Get id of record.
-            $sqlexperiment = $DB->sql_compare_text($prevshortname, strlen($prevshortname));
-            $record = $DB->get_record_sql('SELECT * FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlexperiment));
+            $sql = 'SELECT * FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+            $record = $DB->get_record_sql($sql, ['shortname' => $prevshortname]);
             $return = $DB->update_record('tool_abconfig_experiment', (object) [
                 'id' => $record->id,
                 'name' => $name,
@@ -139,8 +135,8 @@ class tool_abconfig_experiment_manager {
         if (!$this->experiment_exists($shortname)) {
             $return = false;
         } else {
-            $sqlexperiment = $DB->sql_compare_text($shortname, strlen($shortname));
-            $return = $DB->execute('DELETE FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlexperiment));
+            $sql = 'DELETE FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+            $return = $DB->execute($sql, ['shortname' => $shortname]);
         }
         self::invalidate_experiment_cache();
         return $return;
@@ -156,9 +152,11 @@ class tool_abconfig_experiment_manager {
      */
     public function condition_exists($eid, $condset) {
         global $DB;
-        $condsetsql = $DB->sql_compare_text($condset, strlen($condset));
-        $sql = 'SELECT * FROM {tool_abconfig_condition} WHERE experiment = ? AND condset = ?';
-        return $DB->record_exists_sql($sql, array($eid, $condsetsql));
+        $sql = 'SELECT * FROM {tool_abconfig_condition} WHERE experiment = :experiment AND ' . $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset');
+        return $DB->record_exists_sql($sql, [
+            'experiment' => $eid,
+            'condset' => $condset,
+        ]);
     }
 
     /**
@@ -242,9 +240,11 @@ class tool_abconfig_experiment_manager {
         if (!$this->condition_exists($eid, $condset)) {
             $return = false;
         } else {
-            $sqlcondition = $DB->sql_compare_text($condset, strlen($condset));
-            $return = $DB->execute('DELETE FROM {tool_abconfig_condition} WHERE experiment = ? AND condset = ?',
-                array($eid, $sqlcondition));
+            $sql = 'DELETE FROM {tool_abconfig_condition} WHERE experiment = :experiment AND ' . $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset');
+            $return = $DB->execute($sql, [
+                'experiment' => $eid,
+                'condset' => $condset
+            ]);
         }
         self::invalidate_experiment_cache();
         return $return;

--- a/tests/experiment_manager_test.php
+++ b/tests/experiment_manager_test.php
@@ -42,8 +42,8 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $manager->add_experiment('name', 'shortname', 'request');
 
         // Get record and verify fields.
-        $sqlexperiment = $DB->sql_compare_text('shortname', strlen('shortname'));
-        $record = $DB->get_record_sql('SELECT * FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlexperiment));
+        $sql = 'SELECT * FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+        $record = $DB->get_record_sql($sql, ['shortname' => 'shortname']);
 
         $this->assertEquals($record->name, 'name');
         $this->assertEquals($record->shortname, 'shortname');
@@ -66,8 +66,9 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertTrue($manager->experiment_exists('shortname'));
 
         // Now delete this record, and add a new one.
-        $sqlcompare = $DB->sql_compare_text('shortname', strlen('shortname'));
-        $record = $DB->execute('DELETE FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlcompare));
+        $sql = 'DELETE FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+        $DB->execute($sql, ['shortname' => 'shortname']);
+
         $DB->insert_record('tool_abconfig_experiment',
             array('name' => 'name2', 'shortname' => 'shortname2', 'scope' => 'request', 'enabled' => 0));
 
@@ -88,8 +89,8 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $manager->update_experiment('shortname', 'name2', 'shortname2', 'session', 1, 1, 33);
 
         // Get record and verify fields.
-        $sqlexperiment = $DB->sql_compare_text('shortname2', strlen('shortname2'));
-        $record = $DB->get_record_sql('SELECT * FROM {tool_abconfig_experiment} WHERE shortname = ?', array($sqlexperiment));
+        $sql = 'SELECT * FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+        $record = $DB->get_record_sql($sql, ['shortname' => 'shortname2']);
 
         $this->assertEquals($record->name, 'name2');
         $this->assertEquals($record->shortname, 'shortname2');

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -169,13 +169,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 0);
 
         // Update value fields so that core hook executes.
-        $sqlcondition1 = $DB->sql_compare_text('set1', strlen('set1'));
+        $where = $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset') . ' AND experiment = :experiment';
         $DB->set_field_select('tool_abconfig_condition',
-            'value', 0, 'condset = ? AND experiment = ?', array($sqlcondition1, $eid));
+            'value', 0, $where, ['condset' => 'set1', 'experiment' => $eid]);
 
-        $sqlcondition2 = $DB->sql_compare_text('set2', strlen('set2'));
         $DB->set_field_select('tool_abconfig_condition',
-            'value', 100, 'condset = ? AND experiment = ?', array($sqlcondition2, $eid));
+            'value', 100, $where, ['condset' => 'set2', 'experiment' => $eid]);
 
         // Reset configs.
         // Unset forced_plugin_settings so it can be forced again by the plugin.
@@ -280,9 +279,9 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 0);
 
         // Now update condition field to remove ip whitelist, and check that value is updated.
-        $sqlcondition = $DB->sql_compare_text('set1', strlen('set1'));
+        $where = $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset') . ' AND experiment = :experiment';
         $DB->set_field_select('tool_abconfig_condition',
-            'ipwhitelist', '', 'condset = ? AND experiment = ?', array($sqlcondition, $eid));
+            'ipwhitelist', '', $where, ['condset' => 'set1', 'experiment' => $eid]);
 
         // Purge caches to avoid caching issues with changing experiments.
         \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', array(), array('allexperiment'));


### PR DESCRIPTION
Fixes https://github.com/catalyst/moodle-tool_abconfig/issues/92

## Changes
This was an issue in mssql as `$DB->sql_compare_text` was not being used for both the placeholder and the column name (as used elsewhere in core moodle)

Fixed this by replacing these as necessary to get tests passing.

## Testing
- Mssql unit tests - passing locally
- pgsql/mysql - Github actions
