### PR TITLE
Define root namespace for lib.php functions in callbacks

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -16,6 +16,8 @@
 
 namespace tool_abconfig;
 
+require_once(__DIR__ . '/../lib.php');
+
 /**
  * Hook callbacks for tool_abconfig.
  *
@@ -38,7 +40,7 @@ class hook_callbacks {
             return;
         }
 
-        tool_abconfig_execute_js('header');
+        \tool_abconfig_execute_js('header');
     }
 
     /**
@@ -53,7 +55,7 @@ class hook_callbacks {
             return;
         }
 
-        tool_abconfig_execute_js('footer');
+        \tool_abconfig_execute_js('footer');
     }
 
     /**
@@ -69,6 +71,6 @@ class hook_callbacks {
             return;
         }
 
-        tool_abconfig_after_config();
+        \tool_abconfig_after_config();
     }
 }


### PR DESCRIPTION
Add backslashes for `lib.php` functions in `hook_callbacks.php` to define them as from root namespace. Otherwise, PHP might throw an error, as it cannot find the functions in plugins namespace (`tool_abconfig\tool_abconfig_after_config`).