### PR TITLE
 [#73] Handle exception during upgrade to 4.5

### DIFF
--- a/classes/experiment_cache.php
+++ b/classes/experiment_cache.php
@@ -35,7 +35,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class experiment_cache implements \cache_data_source {
-
     /** @var experiment_cache the singleton instance of this class. */
     protected static $experimentcache = null;
 
@@ -60,7 +59,7 @@ class experiment_cache implements \cache_data_source {
      */
     public function load_for_cache($key) {
         global $DB;
-        $data = array();
+        $data = [];
 
         // All experiments.
         if ($key == 'allexperiment') {
@@ -82,7 +81,7 @@ class experiment_cache implements \cache_data_source {
      */
     public function load_many_for_cache(array $keys) {
         // Return array of all data items.
-        $data = array();
+        $data = [];
         foreach ($keys as $key) {
             $data[$key] = self::load_for_cache($key);
         }
@@ -101,8 +100,8 @@ class experiment_cache implements \cache_data_source {
         $experimentdata = (array) $experimentrecord;
 
         // Get all the conditions for the experiment.
-        $records = $DB->get_records('tool_abconfig_condition', array('experiment' => $experimentrecord->id));
-        $data = array();
+        $records = $DB->get_records('tool_abconfig_condition', ['experiment' => $experimentrecord->id]);
+        $data = [];
         foreach ($records as $record) {
             $data[$record->condset] = (array) $record;
         }

--- a/classes/experiment_manager.php
+++ b/classes/experiment_manager.php
@@ -34,7 +34,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_abconfig_experiment_manager {
-
     // Experiment functions.
 
     /** @var array Experiment js that needs to be rendered. */
@@ -243,7 +242,7 @@ class tool_abconfig_experiment_manager {
             $sql = 'DELETE FROM {tool_abconfig_condition} WHERE experiment = :experiment AND ' . $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset');
             $return = $DB->execute($sql, [
                 'experiment' => $eid,
-                'condset' => $condset
+                'condset' => $condset,
             ]);
         }
         self::invalidate_experiment_cache();
@@ -257,7 +256,7 @@ class tool_abconfig_experiment_manager {
      */
     public function delete_all_conditions($eid) {
         global $DB;
-        $DB->delete_records('tool_abconfig_condition', array('experiment' => $eid));
+        $DB->delete_records('tool_abconfig_condition', ['experiment' => $eid]);
         self::invalidate_experiment_cache();
     }
 
@@ -268,7 +267,7 @@ class tool_abconfig_experiment_manager {
      */
     public function get_conditions_for_experiment($eid) {
         global $DB;
-        return $DB->get_records('tool_abconfig_condition', array('experiment' => $eid), 'condset ASC');
+        return $DB->get_records('tool_abconfig_condition', ['experiment' => $eid], 'condset ASC');
     }
 
     // Caching functions.
@@ -278,7 +277,7 @@ class tool_abconfig_experiment_manager {
      * @return void
      */
     private function invalidate_experiment_cache() {
-        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', array(), array('allexperiment'));
+        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', [], ['allexperiment']);
     }
 
     /**
@@ -289,7 +288,7 @@ class tool_abconfig_experiment_manager {
         $cache = cache::make('tool_abconfig', 'experiments');
         $experiments = $cache->get('allexperiment');
         // Return empty array if cache->get fails.
-        return ($experiments != false) ? $experiments : array();
+        return ($experiments != false) ? $experiments : [];
     }
 
     /**
@@ -440,14 +439,14 @@ class tool_abconfig_experiment_manager {
             $command = explode(',', $commandstring);
             switch ($command[0]) {
                 case 'CFG':
-                    $plugin = 'core-experiment:'.$value;
+                    $plugin = 'core-experiment:' . $value;
                     $name = $command[1];
                     $setting = $command[2];
                     add_to_config_log($name, '', $setting, $plugin);
                     break;
 
                 case 'forced_plugin_setting':
-                    $plugin = $command[1].'-experiment:'.$value;
+                    $plugin = $command[1] . '-experiment:' . $value;
                     $name = $command[2];
                     $setting = $command[3];
                     add_to_config_log($name, '', $setting, $plugin);

--- a/classes/form/edit_conditions.php
+++ b/classes/form/edit_conditions.php
@@ -72,26 +72,42 @@ class edit_conditions extends \moodleform {
             $mform->setType("prevshortname{$id}", PARAM_ALPHANUM);
 
             // Section Header.
-            $mform->addElement('header', "header{$id}",
-                get_string('formheader', 'tool_abconfig', $setcount));
+            $mform->addElement(
+                'header',
+                "header{$id}",
+                get_string('formheader', 'tool_abconfig', $setcount)
+            );
             $mform->setExpanded("header{$id}");
 
             // Shortname.
-            $mform->addElement('text', "shortname{$id}",
-                get_string('formexperimentcondsset', 'tool_abconfig'), array("size" => 20));
+            $mform->addElement(
+                'text',
+                "shortname{$id}",
+                get_string('formexperimentcondsset', 'tool_abconfig'),
+                ["size" => 20]
+            );
             $mform->setType("shortname{$id}", PARAM_ALPHANUM);
             $mform->setDefault("shortname{$id}", $record->condset);
             $mform->addRule("shortname{$id}", get_string('formexperimentnamereq', 'tool_abconfig'), 'required');
 
             // IP Whitelist.
-            $mform->addElement('textarea', "iplist{$id}",
-                get_string('formipwhitelist', 'tool_abconfig'), array('rows' => 3, 'cols' => 60));
+            $mform->addElement(
+                'textarea',
+                "iplist{$id}",
+                get_string('formipwhitelist', 'tool_abconfig'),
+                ['rows' => 3, 'cols' => 60]
+            );
             $mform->setType("iplist{$id}", PARAM_TEXT);
             $mform->setDefault("iplist{$id}", $record->ipwhitelist);
 
             // Users.
-            $mform->addElement('autocomplete', "users{$id}",
-                get_string('formexperimentusers', 'tool_abconfig'), [], $useroptions);
+            $mform->addElement(
+                'autocomplete',
+                "users{$id}",
+                get_string('formexperimentusers', 'tool_abconfig'),
+                [],
+                $useroptions
+            );
             $mform->setType("users{$id}", PARAM_TEXT);
             if (!empty($record->users)) {
                 $mform->setDefault("users{$id}", json_decode($record->users));
@@ -102,22 +118,36 @@ class edit_conditions extends \moodleform {
             }
 
             // Commands.
-            $mform->addElement('textarea', "commands{$id}",
-                get_string('formexperimentcommands', 'tool_abconfig'), array('rows' => 6, 'cols' => 60));
+            $mform->addElement(
+                'textarea',
+                "commands{$id}",
+                get_string('formexperimentcommands', 'tool_abconfig'),
+                ['rows' => 6, 'cols' => 60]
+            );
             $mform->setType("commands{$id}", PARAM_TEXT);
             if (!empty($record->commands)) {
                 $mform->setDefault("commands{$id}", implode(PHP_EOL, json_decode($record->commands, true)));
             }
 
             // Value.
-            $mform->addElement('text', "value{$id}",
-                get_string("formexperimentvalue", "tool_abconfig"), array("size" => 20));
+            $mform->addElement(
+                'text',
+                "value{$id}",
+                get_string("formexperimentvalue", "tool_abconfig"),
+                ["size" => 20]
+            );
             $mform->setType("value{$id}", PARAM_TEXT);
             $mform->setDefault("value{$id}", $record->value);
 
             // Delete.
-            $mform->addElement('advcheckbox', "delete{$id}",
-                get_string("formdeleterepeat", "tool_abconfig"), '', array(), array(0, 1));
+            $mform->addElement(
+                'advcheckbox',
+                "delete{$id}",
+                get_string("formdeleterepeat", "tool_abconfig"),
+                '',
+                [],
+                [0, 1]
+            );
             $mform->setDefault("delete{$id}", 0);
 
             $setcount++;
@@ -131,7 +161,7 @@ class edit_conditions extends \moodleform {
         }
 
         // Setup repeating elements array.
-        $repeatarray = array();
+        $repeatarray = [];
 
         $repeatarray[] = $mform->createElement(
             "hidden",
@@ -148,44 +178,44 @@ class edit_conditions extends \moodleform {
             "text",
             "repeatshortname",
             get_string("formexperimentcondsset", "tool_abconfig"),
-            array("size" => 20)
+            ["size" => 20]
         );
 
         $repeatarray[] = $mform->createElement(
             "textarea",
             "repeatiplist",
             get_string("formipwhitelist", "tool_abconfig"),
-            array(
+            [
                 "placeholder" => '127.0.0.1',
                 "rows" => 3,
-                "cols" => 60
-            )
+                "cols" => 60,
+            ]
         );
 
         $repeatarray[] = $mform->createElement(
             "textarea",
             "repeatcommands",
             get_string("formexperimentcommands", "tool_abconfig"),
-            array(
+            [
                 "placeholder" => 'CFG,passwordpolicy,true'
-                .PHP_EOL.'forced_plugin_setting,auth_manual,expiration,yes'
-                .PHP_EOL.'http_header,From,example@example.org'
-                .PHP_EOL.'error_log,example error message'
-                .PHP_EOL."js_header,console.log('example');"
-                .PHP_EOL."js_footer,console.log('example');",
+                . PHP_EOL . 'forced_plugin_setting,auth_manual,expiration,yes'
+                . PHP_EOL . 'http_header,From,example@example.org'
+                . PHP_EOL . 'error_log,example error message'
+                . PHP_EOL . "js_header,console.log('example');"
+                . PHP_EOL . "js_footer,console.log('example');",
                 "rows" => 6,
-                "cols" => 60
-            )
+                "cols" => 60,
+            ]
         );
 
         $repeatarray[] = $mform->createElement(
             "text",
             "repeatvalue",
             get_string("formexperimentvalue", "tool_abconfig"),
-            array(
+            [
                 "size" => 20,
-                "placeholder" => '50'
-            )
+                "placeholder" => '50',
+            ]
         );
 
         $repeatarray[] = $mform->createElement(
@@ -201,13 +231,13 @@ class edit_conditions extends \moodleform {
             "repeatdelete",
             get_string("formdeleterepeat", "tool_abconfig"),
             '',
-            array(),
-            array(0, 1)
+            [],
+            [0, 1]
         );
 
         $repeatarray[] = $mform->addElement("html", "<hr>");
 
-        $repeatoptions = array();
+        $repeatoptions = [];
         $repeatoptions["repeatid"]["default"] = "{no}";
         $repeatoptions["repeatid"]["type"] = PARAM_INT;
 
@@ -219,8 +249,16 @@ class edit_conditions extends \moodleform {
         $repeatoptions["repeatvalue"]["type"] = PARAM_TEXT;
         $repeatoptions["repeatusers"]["type"] = PARAM_TEXT;
 
-        $this->repeat_elements($repeatarray, $count, $repeatoptions, 'repeats',
-            'add_condition', 1, get_string('formaddrepeat', 'tool_abconfig'), false);
+        $this->repeat_elements(
+            $repeatarray,
+            $count,
+            $repeatoptions,
+            'repeats',
+            'add_condition',
+            1,
+            get_string('formaddrepeat', 'tool_abconfig'),
+            false
+        );
 
         $this->add_action_buttons();
     }
@@ -269,9 +307,10 @@ class edit_conditions extends \moodleform {
                     continue;
                 }
                 // Ensure value is numeric in correct range.
-                if ($data['repeatvalue'][$value] < 0 || $data['repeatvalue'][$value] > 100
-                    || !is_numeric($data['repeatvalue'][$value])) {
-
+                if (
+                    $data['repeatvalue'][$value] < 0 || $data['repeatvalue'][$value] > 100
+                    || !is_numeric($data['repeatvalue'][$value])
+                ) {
                     $errors["repeatvalue[$value]"] = get_string('formexperimentvalueerror', 'tool_abconfig');
                 }
                 // Increment total and check value.

--- a/classes/form/edit_experiment.php
+++ b/classes/form/edit_experiment.php
@@ -36,7 +36,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class edit_experiment extends \moodleform {
-
     /**
      * Form definition
      * @return void
@@ -96,14 +95,14 @@ class edit_experiment extends \moodleform {
         $mform->addElement('html', \tool_abconfig\local\table_manager::conditions_table($eid));
 
         // Setup button group.
-        $buttonarray = array();
+        $buttonarray = [];
         $buttonarray[] =& $mform->createElement('submit', 'savechanges', get_string('save'));
         $buttonarray[] =& $mform->createElement('submit', 'conditions', get_string('formeditconditions', 'tool_abconfig'));
         $mform->registerNoSubmitButton('conditions');
         $mform->closeHeaderBefore('conditions');
         $buttonarray[] =& $mform->createElement('cancel', 'cancel', get_string('cancel'));
 
-        $mform->addGroup($buttonarray, 'buttonar', '', array(' '), false);
+        $mform->addGroup($buttonarray, 'buttonar', '', [' '], false);
     }
 
     /**

--- a/classes/form/manage_experiments.php
+++ b/classes/form/manage_experiments.php
@@ -37,7 +37,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class manage_experiments extends \moodleform {
-
     /**
      * Form definition
      * @return void
@@ -56,17 +55,30 @@ class manage_experiments extends \moodleform {
         $mform->addElement('header', 'addexperiment', get_string('formaddexperiment', 'tool_abconfig'));
 
         // Name.
-        $mform->addElement('text', 'experimentname',
-            get_string('formexperimentname', 'tool_abconfig'), array('placeholder' => 'Experiment'));
+        $mform->addElement(
+            'text',
+            'experimentname',
+            get_string('formexperimentname', 'tool_abconfig'),
+            ['placeholder' => 'Experiment']
+        );
         $mform->setType('experimentname', PARAM_TEXT);
         $mform->addRule('experimentname', get_string('formexperimentnamereq', 'tool_abconfig'), 'required', null, 'client');
 
         // Short Name.
-        $mform->addElement('text', 'experimentshortname',
-            get_string('formexperimentshortname', 'tool_abconfig'), array('placeholder' => 'experiment'));
+        $mform->addElement(
+            'text',
+            'experimentshortname',
+            get_string('formexperimentshortname', 'tool_abconfig'),
+            ['placeholder' => 'experiment']
+        );
         $mform->setType('experimentshortname', PARAM_ALPHANUM);
-        $mform->addRule('experimentshortname',
-            get_string('formexperimentshortnamereq', 'tool_abconfig'), 'required', null, 'client');
+        $mform->addRule(
+            'experimentshortname',
+            get_string('formexperimentshortnamereq', 'tool_abconfig'),
+            'required',
+            null,
+            'client'
+        );
 
         // Select Scope.
         $mform->addElement('select', 'scope', get_string('formexperimentscopeselect', 'tool_abconfig'), $scopes);

--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -25,7 +25,6 @@ namespace tool_abconfig;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hook_callbacks {
-
     /**
      * Runs before HTTP headers.
      *

--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -69,6 +69,11 @@ class hook_callbacks {
             return;
         }
 
+        // Handles edge case during upgrade & install where this callback doesn't have the lib loaded.
+        if (!function_exists('tool_abconfig_after_config')) {
+            require_once($CFG->dirroot . '/admin/tool/abconfig/lib.php');
+        }
+
         tool_abconfig_after_config();
     }
 }

--- a/classes/local/table_manager.php
+++ b/classes/local/table_manager.php
@@ -46,19 +46,19 @@ class table_manager {
 
         $records = $DB->get_records('tool_abconfig_experiment');
         // Get header strings.
-        $wantstrings = array('name', 'shortname', 'scope', 'edit', 'enabled', 'adminenabled');
+        $wantstrings = ['name', 'shortname', 'scope', 'edit', 'enabled', 'adminenabled'];
         $strings = get_strings($wantstrings, 'tool_abconfig');
         // Generate table header.
         $table = new \html_table();
-        $table->head = array(get_string('idnumber'), $strings->name, $strings->shortname,
-            $strings->scope, $strings->enabled, $strings->adminenabled, $strings->edit);
+        $table->head = [get_string('idnumber'), $strings->name, $strings->shortname,
+            $strings->scope, $strings->enabled, $strings->adminenabled, $strings->edit];
         $table->attributes['class'] = 'generaltable table table-bordered';
-        $table->colclasses = array('centeralign', 'centeralign', 'centeralign',
-            'centeralign', 'centeralign', 'centeralign', 'centeralign');
+        $table->colclasses = ['centeralign', 'centeralign', 'centeralign',
+            'centeralign', 'centeralign', 'centeralign', 'centeralign'];
 
         foreach ($records as $record) {
             // Setup edit link.
-            $url = new \moodle_url('/admin/tool/abconfig/edit_experiment.php', array('id' => $record->id));
+            $url = new \moodle_url('/admin/tool/abconfig/edit_experiment.php', ['id' => $record->id]);
             if ($record->enabled == 0) {
                 $enabled = get_string('no');
             } else {
@@ -72,8 +72,8 @@ class table_manager {
             }
 
             // Add table row.
-            $table->data[] = array($record->id, $record->name, $record->shortname,
-                $record->scope, $enabled, $adminenabled, \html_writer::link($url, get_string('edit')));
+            $table->data[] = [$record->id, $record->name, $record->shortname,
+                $record->scope, $enabled, $adminenabled, \html_writer::link($url, get_string('edit'))];
         }
         return \html_writer::table($table);
     }
@@ -89,26 +89,26 @@ class table_manager {
         global $DB;
 
         // Get all lang strings for table header.
-        $stringsreqd = array(
+        $stringsreqd = [
             'formipwhitelist',
             'formexperimentcommands',
             'formexperimentvalue',
             'formexperimentcondsset',
             'formexperimentusers',
             'formexperimentforceurl',
-        );
+        ];
         $stringarr = get_strings($stringsreqd, 'tool_abconfig');
 
         // Setup table.
         $table = new \html_table();
-        $table->head = array(
+        $table->head = [
             $stringarr->formexperimentcondsset,
             $stringarr->formipwhitelist,
             $stringarr->formexperimentcommands,
             $stringarr->formexperimentvalue,
             $stringarr->formexperimentusers,
             $stringarr->formexperimentforceurl,
-        );
+        ];
         $table->attributes['class'] = 'generaltable table table-bordered';
 
         // Get experiment conditions records.
@@ -139,14 +139,14 @@ class table_manager {
             // Construct URL for forcing condition.
             $paramstring = '?';
             // Get experiment shortname.
-            $experiment = $DB->get_record('tool_abconfig_experiment', array('id' => $eid));
+            $experiment = $DB->get_record('tool_abconfig_experiment', ['id' => $eid]);
             $paramstring .= $experiment->shortname . '=';
             $paramstring .= $record->condset;
 
             // URL for redirecting to the dashboard with conditions active.
-            $url = new \moodle_url('/my/', array($experiment->shortname => $record->condset));
+            $url = new \moodle_url('/my/', [$experiment->shortname => $record->condset]);
 
-            $table->data[] = array($record->condset, $iplist, $commands, $record->value, $users, \html_writer::link($url, $paramstring));
+            $table->data[] = [$record->condset, $iplist, $commands, $record->value, $users, \html_writer::link($url, $paramstring)];
         }
 
         return \html_writer::table($table);

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -38,14 +38,13 @@ defined('MOODLE_INTERNAL') || die();
 class provider implements
     // This plugin does not store any personal user data.
     \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/db/caches.php
+++ b/db/caches.php
@@ -24,11 +24,10 @@
  */
 defined('MOODLE_INTERNAL') || die;
 
-$definitions = array(
-    'experiments' => array(
+$definitions = [
+    'experiments' => [
         'mode' => cache_store::MODE_APPLICATION,
         'datasource' => '\tool_abconfig\experiment_cache',
-        'staticacceleration' => true
-    )
-);
-
+        'staticacceleration' => true,
+    ],
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -46,7 +46,6 @@ function xmldb_tool_abconfig_upgrade($oldversion) {
     }
 
     if ($oldversion < 2025011300) {
-
         // Define field numoffset to be added to tool_abconfig_experiment.
         $table = new xmldb_table('tool_abconfig_experiment');
         $field = new xmldb_field('numoffset', XMLDB_TYPE_INTEGER, '5', null, null, null, null, 'adminenabled');

--- a/edit_conditions.php
+++ b/edit_conditions.php
@@ -41,18 +41,17 @@ $PAGE->set_url($url);
 
 $manager = new tool_abconfig_experiment_manager();
 
-$prevurl = ($CFG->wwwroot."/admin/tool/abconfig/edit_experiment.php?id=$eid");
+$prevurl = ($CFG->wwwroot . "/admin/tool/abconfig/edit_experiment.php?id=$eid");
 
-$customdata = array('eid' => $eid);
+$customdata = ['eid' => $eid];
 
-$experiment = $DB->get_record('tool_abconfig_experiment', array('id' => $eid));
+$experiment = $DB->get_record('tool_abconfig_experiment', ['id' => $eid]);
 
 $form = new \tool_abconfig\form\edit_conditions($url, $customdata);
 
 if ($form->is_cancelled()) {
     redirect($prevurl);
 } else if ($fromform = $form->get_data()) {
-
     $eid = $fromform->eid;
     // Page doesnt have an experiment, do nothing.
     if (empty($eid)) {
@@ -60,7 +59,7 @@ if ($form->is_cancelled()) {
     }
 
     // Updating old data.
-    $records = $DB->get_records('tool_abconfig_condition', array('experiment' => $eid), 'id ASC');
+    $records = $DB->get_records('tool_abconfig_condition', ['experiment' => $eid], 'id ASC');
     foreach ($records as $record) {
         $prevshortname = "prevshortname{$record->id}";
         $shortname = "shortname{$record->id}";
@@ -75,8 +74,16 @@ if ($form->is_cancelled()) {
             $manager->delete_condition($eid, $fromform->$shortname);
         } else {
             // Else write data back to DB.
-            $manager->update_condition($eid, $record->id, $fromform->$prevshortname,
-                $fromform->$shortname, $fromform->$iplist, $fromform->$commandskey, $fromform->$value, $fromform->$users);
+            $manager->update_condition(
+                $eid,
+                $record->id,
+                $fromform->$prevshortname,
+                $fromform->$shortname,
+                $fromform->$iplist,
+                $fromform->$commandskey,
+                $fromform->$value,
+                $fromform->$users
+            );
         }
     }
 
@@ -84,7 +91,6 @@ if ($form->is_cancelled()) {
     if (!empty($fromform->repeatid)) {
         $repeats = array_keys($fromform->repeatid);
         foreach ($repeats as $key => $value) {
-
             // Protect from empty data.
             if (empty($fromform->repeatshortname[$value])) {
                 continue;
@@ -94,17 +100,21 @@ if ($form->is_cancelled()) {
                 // If accidentally added condition set and wishes to delete.
                 continue;
             } else {
-                $manager->add_condition($eid, $fromform->repeatshortname[$value], $fromform->repeatiplist[$value],
-                    $fromform->repeatcommands[$value], $fromform->repeatvalue[$value], $fromform->repeatusers[$value]);
+                $manager->add_condition(
+                    $eid,
+                    $fromform->repeatshortname[$value],
+                    $fromform->repeatiplist[$value],
+                    $fromform->repeatcommands[$value],
+                    $fromform->repeatvalue[$value],
+                    $fromform->repeatusers[$value]
+                );
             }
         }
     }
 
     // Back to experiment.
     redirect($prevurl);
-
 } else {
-
     // Build the page output.
     echo $OUTPUT->header();
     echo $OUTPUT->heading(get_string('editexperimentpagename', 'tool_abconfig'));

--- a/edit_experiment.php
+++ b/edit_experiment.php
@@ -33,12 +33,12 @@ require_login();
 require_capability('moodle/site:config', context_system::instance());
 
 $eid = optional_param('id', 0, PARAM_INT);
-$PAGE->set_url(new moodle_url('/admin/tool/abconfig/edit_experiment', array ('id' => $eid)));
+$PAGE->set_url(new moodle_url('/admin/tool/abconfig/edit_experiment', ['id' => $eid]));
 
 if ($node = $PAGE->settingsnav->find('root', \navigation_node::TYPE_SITE_ADMIN)) {
     $PAGE->navbar->add($node->get_content(), $node->action());
 }
-foreach (array('tools', 'abconfig', 'tool_abconfig_manageexperiments') as $label) {
+foreach (['tools', 'abconfig', 'tool_abconfig_manageexperiments'] as $label) {
     if ($node = $PAGE->settingsnav->find($label, \navigation_node::TYPE_SETTING)) {
         $PAGE->navbar->add($node->get_content(), $node->action());
     }
@@ -46,22 +46,22 @@ foreach (array('tools', 'abconfig', 'tool_abconfig_manageexperiments') as $label
 $PAGE->navbar->add(get_string('editexperimentpagename', 'tool_abconfig'));
 
 $manager = new tool_abconfig_experiment_manager();
-$experiment = $DB->get_record('tool_abconfig_experiment', array('id' => $eid));
-$data = array('experimentname' => $experiment->name, 'experimentshortname' => $experiment->shortname,
+$experiment = $DB->get_record('tool_abconfig_experiment', ['id' => $eid]);
+$data = ['experimentname' => $experiment->name, 'experimentshortname' => $experiment->shortname,
     'prevshortname' => $experiment->shortname, 'scope' => $experiment->scope,
     'id' => $experiment->id, 'enabled' => $experiment->enabled, 'adminenabled' => $experiment->adminenabled,
-    'numoffset' => $experiment->numoffset ?? rand(0, 99));
+    'numoffset' => $experiment->numoffset ?? rand(0, 99)];
 
-$customarray = array('eid' => $experiment->id);
+$customarray = ['eid' => $experiment->id];
 
-$prevurl = ($CFG->wwwroot.'/admin/tool/abconfig/manage_experiments.php');
+$prevurl = ($CFG->wwwroot . '/admin/tool/abconfig/manage_experiments.php');
 $form = new \tool_abconfig\form\edit_experiment(null, $customarray);
 $form->set_data($data);
 if ($form->is_cancelled()) {
     redirect($prevurl);
 } else if ($form->no_submit_button_pressed()) {
     // Conditions button action.
-    redirect(new moodle_url('/admin/tool/abconfig/edit_conditions.php', array('id' => $experiment->id)));
+    redirect(new moodle_url('/admin/tool/abconfig/edit_conditions.php', ['id' => $experiment->id]));
 } else if ($fromform = $form->get_data()) {
     // Form validation means data is safe to go to DB.
 
@@ -89,9 +89,7 @@ if ($form->is_cancelled()) {
     }
 
     redirect($prevurl);
-
 } else {
-
     // Build the page output.
     echo $OUTPUT->header();
     echo $OUTPUT->heading(get_string('editexperimentpagename', 'tool_abconfig'));

--- a/lib.php
+++ b/lib.php
@@ -37,7 +37,6 @@ function tool_abconfig_after_config() {
     global $SESSION, $USER, $CFG;
 
     try {
-
         // Setup experiment manager.
         $manager = new tool_abconfig_experiment_manager();
 
@@ -51,12 +50,10 @@ function tool_abconfig_after_config() {
         // Get all after congig experiments and check params.
         $experiments = $manager->get_after_config_experiments();
         foreach ($experiments as $experiment => $contents) {
-
             if (defined('CLI_SCRIPT') && CLI_SCRIPT) {
                 // Check ENV vars set on the cli.
                 $condition = getenv('ABCONFIG_' . strtoupper($experiment));
             } else {
-
                 // Check URL params, and fire any experiments in the params.
                 $condition = optional_param($experiment, null, PARAM_TEXT);
 
@@ -72,12 +69,14 @@ function tool_abconfig_after_config() {
 
             // Ensure condition set exists before executing.
             if (array_key_exists($condition, $contents['conditions'])) {
-                tool_abconfig_execute_command_array($contents['conditions'][$condition]['commands'],
-                    $contents['shortname']);
+                tool_abconfig_execute_command_array(
+                    $contents['conditions'][$condition]['commands'],
+                    $contents['shortname']
+                );
             }
         }
 
-        $commandarray = array();
+        $commandarray = [];
 
         // First, Build a list of all commands that need to be executed.
 
@@ -85,7 +84,6 @@ function tool_abconfig_after_config() {
         $requestexperiments = $manager->get_active_request();
         if (!empty($requestexperiments)) {
             foreach ($requestexperiments as $record) {
-
                 // Make admin immune unless enabled for admin.
                 if (is_siteadmin()) {
                     if ($record['adminenabled'] == 0) {
@@ -96,7 +94,7 @@ function tool_abconfig_after_config() {
                 $conditionrecords = $record['conditions'];
 
                 // Remove all conditions that contain the user ip in the whitelist.
-                $crecords = array();
+                $crecords = [];
 
                 foreach ($conditionrecords as $conditionrecord) {
                     $iplist = $conditionrecord['ipwhitelist'];
@@ -131,7 +129,7 @@ function tool_abconfig_after_config() {
         if (!empty($sessionexperiments)) {
             foreach ($sessionexperiments as $record) {
                 // Check if a session var has been set for this experiment, only care if has been set.
-                $unique = 'abconfig_'.$record['shortname'];
+                $unique = 'abconfig_' . $record['shortname'];
                 if (property_exists($SESSION, $unique) && $SESSION->$unique != '') {
                     $commandarray[$record['shortname']] = $record['conditions'][$SESSION->$unique]['commands'];
                 }
@@ -176,7 +174,6 @@ function tool_abconfig_before_session_start() {
         // Get all before session experiments and check params.
         $experiments = $manager->get_before_session_experiments();
         foreach ($experiments as $experiment => $contents) {
-
             // Check URL params, and fire any experiments in the params.
             $condition = optional_param($experiment, null, PARAM_TEXT);
             if (empty($condition)) {
@@ -185,8 +182,10 @@ function tool_abconfig_before_session_start() {
 
             // Ensure condition set exists before executing.
             if (array_key_exists($condition, $contents['conditions'])) {
-                tool_abconfig_execute_command_array($contents['conditions'][$condition]['commands'],
-                    $contents['shortname']);
+                tool_abconfig_execute_command_array(
+                    $contents['conditions'][$condition]['commands'],
+                    $contents['shortname']
+                );
             }
         }
 
@@ -200,7 +199,6 @@ function tool_abconfig_before_session_start() {
             $hash = md5($_SERVER['REMOTE_ADDR'] . $_SERVER['HTTP_USER_AGENT']);
             $basenum = hexdec(substr($hash, 0, 8)) % 100;
             foreach ($deviceexperiments as $record) {
-
                 // Admins are not immune from device experiments by default.
                 $conditionrecords = $record['conditions'];
 
@@ -270,11 +268,11 @@ function tool_abconfig_after_require_login() {
             }
 
             // Create experiment session var identifier.
-            $unique = 'abconfig_'.$record['shortname'];
+            $unique = 'abconfig_' . $record['shortname'];
             // Get condition sets for experiment.
             $conditionrecords = $record['conditions'];
             // Remove all conditions that contain the user ip in the whitelist.
-            $crecords = array();
+            $crecords = [];
 
             foreach ($conditionrecords as $conditionrecord) {
                 $iplist = $conditionrecord['ipwhitelist'];
@@ -301,7 +299,6 @@ function tool_abconfig_after_require_login() {
 
                         // Do not execute any more conditions.
                         break;
-
                     } else {
                         // Not this record, increment lower bound, and move on.
                         $prevtotal += $crecord['value'];
@@ -359,7 +356,6 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
     $manager = new tool_abconfig_experiment_manager();
     $commands = json_decode($commandsencoded);
     foreach ($commands as $commandstring) {
-
         $command = strtok($commandstring, ',');
 
         // Check for core commands.
@@ -385,10 +381,11 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
 
             // Ensure that command hasnt already been forced in config.php or that overriding is allowed.
             // If plugin settings array doesnt exist, or the actual config key doesnt exist.
-            if (!array_key_exists($commandarray[1], $CFG->forced_plugin_settings) ||
+            if (
+                !array_key_exists($commandarray[1], $CFG->forced_plugin_settings) ||
                     !array_key_exists($commandarray[2], $CFG->forced_plugin_settings[$commandarray[1]]) ||
-                    array_key_exists($commandarray[2] . '_allow_abconfig', $CFG->forced_plugin_settings[$commandarray[1]])) {
-
+                    array_key_exists($commandarray[2] . '_allow_abconfig', $CFG->forced_plugin_settings[$commandarray[1]])
+            ) {
                 $CFG->forced_plugin_settings[$commandarray[1]][$commandarray[2]] = $commandarray[3];
             } else {
                 // Debugging shouldn't be used before sessions are loaded.
@@ -407,23 +404,21 @@ function tool_abconfig_execute_command_array($commandsencoded, $shortname, $js =
             $commandarray = explode(',', $commandstring, 2);
             // Must ignore coding standards as typically error_log is not allowed.
             error_log($commandarray[1]); // @codingStandardsIgnoreLine
-
         }
         if ($command == 'js_header') {
             // Check for JS header scripts.
             $commandarray = explode(',', $commandstring, 2);
             // Set a unique manager variable to be picked up by renderer hooks, to emit JS in the right areas.
-            $jsheaderunique = 'abconfig_js_header_'.$shortname;
+            $jsheaderunique = 'abconfig_js_header_' . $shortname;
 
             // Store the unique in the manager to be picked up by the header render hook.
             $manager->set_render_js($jsheaderunique, $commandarray[1]);
-
         }
         if ($command == 'js_footer') {
             // Check for JS footer scripts.
             $commandarray = explode(',', $commandstring, 2);
             // Set a unique manager variable to be picked up by renderer hooks, to emit JS in the right areas.
-            $jsfooterunique = 'abconfig_js_footer_'.$shortname;
+            $jsfooterunique = 'abconfig_js_footer_' . $shortname;
             // Store the javascript in the manager unique to be picked up by the footer render hook.
             $manager->set_render_js($jsfooterunique, $commandarray[1]);
         }
@@ -451,9 +446,9 @@ function tool_abconfig_execute_js(string $type) {
     foreach ($records as $record) {
         // If called from header.
         if ($type == 'header') {
-            $unique = 'abconfig_js_header_'.$record['shortname'];
+            $unique = 'abconfig_js_header_' . $record['shortname'];
         } else if ($type == 'footer') {
-            $unique = 'abconfig_js_footer_'.$record['shortname'];
+            $unique = 'abconfig_js_footer_' . $record['shortname'];
         }
 
         if (array_key_exists($unique, $renderjs)) {

--- a/manage_experiments.php
+++ b/manage_experiments.php
@@ -30,7 +30,7 @@ $manager = new tool_abconfig_experiment_manager();
 
 admin_externalpage_setup('tool_abconfig_manageexperiments');
 
-$prevurl = ($CFG->wwwroot.'/admin/category.php?category=abconfig');
+$prevurl = ($CFG->wwwroot . '/admin/category.php?category=abconfig');
 
 $form = new \tool_abconfig\form\manage_experiments();
 if ($form->is_cancelled()) {

--- a/settings.php
+++ b/settings.php
@@ -28,12 +28,13 @@ defined('MOODLE_INTERNAL') || die;
 global $CFG;
 
 if ($hassiteconfig) {
-
     // Create category for settings and external pages.
     $ADMIN->add('tools', new admin_category('abconfig', get_string('pluginname', 'tool_abconfig')));
 
     // Add external page for managing experiments.
-    $ADMIN->add('abconfig', new admin_externalpage('tool_abconfig_manageexperiments',
-    get_string('manageexperimentspagename', 'tool_abconfig'),
-    new moodle_url('/admin/tool/abconfig/manage_experiments.php')));
+    $ADMIN->add('abconfig', new admin_externalpage(
+        'tool_abconfig_manageexperiments',
+        get_string('manageexperimentspagename', 'tool_abconfig'),
+        new moodle_url('/admin/tool/abconfig/manage_experiments.php')
+    ));
 }

--- a/tests/experiment_manager_test.php
+++ b/tests/experiment_manager_test.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../lib.php');
+require_once(__DIR__ . '/../lib.php');
 
 /**
  * Testing class for hooks in lib.php
@@ -31,9 +31,8 @@ require_once(__DIR__.'/../lib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
-
-    public function test_add_experiment() {
+final class experiment_manager_test extends advanced_testcase {
+    public function test_add_experiment(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
@@ -50,7 +49,7 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertEquals($record->scope, 'request');
     }
 
-    public function test_experiment_exists() {
+    public function test_experiment_exists(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
@@ -59,8 +58,10 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertFalse($manager->experiment_exists('shortname'));
 
         // Manually add experiment.
-        $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
+        $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
 
         // Verify that experiment is found.
         $this->assertTrue($manager->experiment_exists('shortname'));
@@ -69,21 +70,25 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $sql = 'DELETE FROM {tool_abconfig_experiment} WHERE ' . $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
         $DB->execute($sql, ['shortname' => 'shortname']);
 
-        $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name2', 'shortname' => 'shortname2', 'scope' => 'request', 'enabled' => 0));
+        $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name2', 'shortname' => 'shortname2', 'scope' => 'request', 'enabled' => 0]
+        );
 
         // Verify the first record still isnt found.
         $this->assertFalse($manager->experiment_exists('shortname'));
     }
 
-    public function test_update_experiment() {
+    public function test_update_experiment(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment.
-        $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
+        $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
 
         // Update all the values of the experiment.
         $manager->update_experiment('shortname', 'name2', 'shortname2', 'session', 1, 1, 33);
@@ -100,16 +105,20 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertEquals($record->numoffset, 33);
     }
 
-    public function test_delete_experiment() {
+    public function test_delete_experiment(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment.
-        $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
-        $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname2', 'scope' => 'request', 'enabled' => 0));
+        $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
+        $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname2', 'scope' => 'request', 'enabled' => 0]
+        );
 
         $manager->delete_experiment('shortname');
 
@@ -119,40 +128,48 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertEquals('shortname2', reset($records)->shortname);
     }
 
-    public function test_condition_exists() {
+    public function test_condition_exists(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
 
         // Check returns false for unfound condition set.
         $this->assertFalse($manager->condition_exists($eid, 'condset1'));
 
         // Manually add condition set.
-        $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
+        $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
 
         // Verify now found.
         $this->assertTrue($manager->condition_exists($eid, 'condset1'));
     }
 
-    public function test_add_condition() {
+    public function test_add_condition(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
 
         // Add condition for experiment.
         $manager->add_condition($eid, 'condset1', '', '', 50, '');
 
-        $records = $DB->get_records('tool_abconfig_condition',
-            array('experiment' => $eid));
+        $records = $DB->get_records(
+            'tool_abconfig_condition',
+            ['experiment' => $eid]
+        );
 
         // Verify fields of inserted record.
         $this->assertEquals(count($records), 1);
@@ -162,66 +179,82 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
         $this->assertEquals(reset($records)->value, 50);
     }
 
-    public function test_update_condition() {
+    public function test_update_condition(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment and condition.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
-        $id = $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
+        $id = $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
 
         // Update condition.
         $manager->update_condition($eid, $id, 'condset1', 'condset2', '123.123.123.123', 'command', 51, '');
 
-        $record = $DB->get_record('tool_abconfig_condition', array('experiment' => $eid));
+        $record = $DB->get_record('tool_abconfig_condition', ['experiment' => $eid]);
         $this->assertEquals($record->condset, 'condset2');
         $this->assertEquals($record->ipwhitelist, '123.123.123.123');
         $this->assertEquals($record->commands, '["command"]');
         $this->assertEquals($record->value, 51);
     }
 
-    public function test_delete_condition() {
+    public function test_delete_condition(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment and condition.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
-        $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
-        $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset2', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
+        $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
+        $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset2', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
 
         $manager->delete_condition($eid, 'condset1');
 
         // Check that only 1 was deleted, and that the remaining condition is not the deleted one.
-        $records = $DB->get_records('tool_abconfig_condition', array('experiment' => $eid));
+        $records = $DB->get_records('tool_abconfig_condition', ['experiment' => $eid]);
 
         $this->assertEquals(count($records), 1);
         $this->assertEquals(reset($records)->condset, 'condset2');
     }
 
-    public function test_delete_all_conditions() {
+    public function test_delete_all_conditions(): void {
         $this->resetAfterTest(true);
         global $DB;
         $manager = new tool_abconfig_experiment_manager();
 
         // Manually add experiment and condition.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0));
-        $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
-        $DB->insert_record('tool_abconfig_condition',
-            array('experiment' => $eid, 'condset' => 'condset2', 'ipwhitelist' => '', 'commands' => '', 'value' => 50));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'name', 'shortname' => 'shortname', 'scope' => 'request', 'enabled' => 0]
+        );
+        $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset1', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
+        $DB->insert_record(
+            'tool_abconfig_condition',
+            ['experiment' => $eid, 'condset' => 'condset2', 'ipwhitelist' => '', 'commands' => '', 'value' => 50]
+        );
 
         $manager->delete_all_conditions($eid);
 
         // Check that only 1 was deleted, and that the remaining condition is not the deleted one.
-        $records = $DB->get_records('tool_abconfig_condition', array('experiment' => $eid));
+        $records = $DB->get_records('tool_abconfig_condition', ['experiment' => $eid]);
 
         $this->assertEquals(count($records), 0);
     }
@@ -231,7 +264,7 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
      *
      * @return array
      */
-    public function trim_condition_commands_provider() {
+    public function trim_condition_commands_provider(): array {
         return [
             ['CFG,passwordpolicy,1', '["CFG,passwordpolicy,1"]'],
             ['forced_plugin_setting,auth_manual,expiration,yes', '["forced_plugin_setting,auth_manual,expiration,yes"]'],
@@ -249,14 +282,14 @@ class tool_abconfig_experiment_manager_testcase extends advanced_testcase {
      * @param string $actual Actual string that needs to be stored in DB
      * @param string $expected Stored string
      */
-    public function test_trim_condition_commands(string $actual, string $expected) {
+    public function test_trim_condition_commands(string $actual, string $expected): void {
         global $DB;
         $this->resetAfterTest();
         $manager = new tool_abconfig_experiment_manager();
         $experiment = $manager->add_experiment('name', 'shortname', 'request');
         $condition = $manager->add_condition($experiment, 'condset1', '', $actual, 50, '');
 
-        $stored = $DB->get_field('tool_abconfig_condition', 'commands', array('id' => $condition));
+        $stored = $DB->get_field('tool_abconfig_condition', 'commands', ['id' => $condition]);
         $this->assertEquals($expected, $stored);
     }
 }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die();
-require_once(__DIR__.'/../lib.php');
+require_once(__DIR__ . '/../lib.php');
 
 /**
  * Testing class for hooks in lib.php
@@ -31,9 +31,8 @@ require_once(__DIR__.'/../lib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_abconfig_lib_test extends advanced_testcase {
-
-    public function test_request_no_experiment() {
+final class lib_test extends advanced_testcase {
+    public function test_request_no_experiment(): void {
         $this->resetAfterTest(true);
         global $CFG;
 
@@ -50,7 +49,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertSame($preconfig, $CFG);
     }
 
-    public function test_request_admin_immunity() {
+    public function test_request_admin_immunity(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -61,10 +60,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
         // Call the hook.
         tool_abconfig_after_config();
@@ -73,7 +74,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 0);
     }
 
-    public function test_request_core_experiment() {
+    public function test_request_core_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -86,10 +87,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
         // Call the hook.
         tool_abconfig_after_config();
@@ -106,7 +109,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_request_plugin_experiment() {
+    public function test_request_plugin_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -119,10 +122,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('expiration', 'no', 'auth_manual');
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100]);
 
         // Call the hook.
         tool_abconfig_after_config();
@@ -138,7 +143,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals(get_config('auth_manual', 'expiration'), 'yes');
     }
 
-    public function test_request_multi_condition() {
+    public function test_request_multi_condition(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -154,14 +159,16 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and multi conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100]);
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set2', 'value' => 0));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set2', 'value' => 0]);
 
         // Now execute first hook, and check the plugin value.
         tool_abconfig_after_config();
@@ -170,11 +177,21 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Update value fields so that core hook executes.
         $where = $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset') . ' AND experiment = :experiment';
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 0, $where, ['condset' => 'set1', 'experiment' => $eid]);
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            0,
+            $where,
+            ['condset' => 'set1', 'experiment' => $eid]
+        );
 
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 100, $where, ['condset' => 'set2', 'experiment' => $eid]);
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            100,
+            $where,
+            ['condset' => 'set2', 'experiment' => $eid]
+        );
 
         // Reset configs.
         // Unset forced_plugin_settings so it can be forced again by the plugin.
@@ -184,7 +201,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Purge caches to avoid caching issues with changing experiments.
-        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', array(), array('allexperiment'));
+        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', [], ['allexperiment']);
         // Now execute second hook, and check the plugin value.
         tool_abconfig_after_config();
         $this->assertEquals(get_config('auth_manual', 'expiration'), 'no');
@@ -198,19 +215,29 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Update value fields so either one may fire equally.
         $sqlcondition3 = $DB->sql_compare_text('set1', strlen('set1'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 50, 'condset = ? AND experiment = ?', array($sqlcondition3, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            50,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition3, $eid]
+        );
 
         $sqlcondition4 = $DB->sql_compare_text('set2', strlen('set2'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 50, 'condset = ? AND experiment = ?', array($sqlcondition4, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            50,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition4, $eid]
+        );
 
         // Now execute second hook, and check the plugin value.
         tool_abconfig_after_config();
         $this->assertTrue((get_config('auth_manual', 'expiration') == 'yes') xor ($CFG->passwordpolicy == 1));
     }
 
-    public function test_request_multi_command() {
+    public function test_request_multi_command(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -225,16 +252,18 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and multi conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
 
-        $record = array(
+        $record = [
             'experiment' => $eid,
             'ipwhitelist' => '0.0.0.1',
             'commands' => '["forced_plugin_setting,auth_manual,expiration,yes","CFG,passwordpolicy,1"]',
             'condset' => 'set1',
             'value' => 100,
-        );
+        ];
         $DB->insert_record('tool_abconfig_condition', $record);
 
         // Now execute first hook, and check the plugin value.
@@ -254,7 +283,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_request_ip_whitelist() {
+    public function test_request_ip_whitelist(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -267,11 +296,13 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and multi conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'request', 'enabled' => 1]
+        );
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '123.123.123.123',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '123.123.123.123',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
         // Now execute first hook, and check core value hasnt changed.
         tool_abconfig_after_config();
@@ -280,17 +311,22 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Now update condition field to remove ip whitelist, and check that value is updated.
         $where = $DB->sql_compare_text('condset') . ' = ' . $DB->sql_compare_text(':condset') . ' AND experiment = :experiment';
-        $DB->set_field_select('tool_abconfig_condition',
-            'ipwhitelist', '', $where, ['condset' => 'set1', 'experiment' => $eid]);
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'ipwhitelist',
+            '',
+            $where,
+            ['condset' => 'set1', 'experiment' => $eid]
+        );
 
         // Purge caches to avoid caching issues with changing experiments.
-        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', array(), array('allexperiment'));
+        \cache_helper::invalidate_by_definition('tool_abconfig', 'experiments', [], ['allexperiment']);
 
         tool_abconfig_after_config();
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_session_no_execute() {
+    public function test_session_no_execute(): void {
         $this->resetAfterTest(true);
         global $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -308,7 +344,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertSame($preconfig, $CFG);
     }
 
-    public function test_session_admin_immunity () {
+    public function test_session_admin_immunity(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -319,10 +355,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
         // Call the hook.
         tool_abconfig_after_require_login();
@@ -331,7 +369,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 0);
     }
 
-    public function test_session_core_experiment() {
+    public function test_session_core_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -344,13 +382,15 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,0"]', 'condset' => 'set2', 'value' => 0));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,0"]', 'condset' => 'set2', 'value' => 0]);
 
         // Call the hook and verify result.
         tool_abconfig_after_require_login();
@@ -358,12 +398,22 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Now update the values to force the opposite control, and ensure actual config doesnt change.
         $sqlcondition1 = $DB->sql_compare_text('set1', strlen('set1'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 0, 'condset = ? AND experiment = ?', array($sqlcondition1, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            0,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition1, $eid]
+        );
 
         $sqlcondition2 = $DB->sql_compare_text('set2', strlen('set2'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 100, 'condset = ? AND experiment = ?', array($sqlcondition2, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            100,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition2, $eid]
+        );
 
         // Call the hook and test for no change.
         tool_abconfig_after_require_login();
@@ -377,7 +427,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_session_plugin_experiment() {
+    public function test_session_plugin_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -390,13 +440,15 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('expiration', 'no', 'auth_manual');
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set1', 'value' => 100]);
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set2', 'value' => 0));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set2', 'value' => 0]);
 
         // Call the hook and verify result.
         tool_abconfig_after_require_login();
@@ -404,12 +456,22 @@ class tool_abconfig_lib_test extends advanced_testcase {
 
         // Change experiment conditions so the other set always fires.
         $sqlcondition1 = $DB->sql_compare_text('set1', strlen('set1'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 0, 'condset = ? AND experiment = ?', array($sqlcondition1, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            0,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition1, $eid]
+        );
 
         $sqlcondition2 = $DB->sql_compare_text('set2', strlen('set2'));
-        $DB->set_field_select('tool_abconfig_condition',
-            'value', 100, 'condset = ? AND experiment = ?', array($sqlcondition2, $eid));
+        $DB->set_field_select(
+            'tool_abconfig_condition',
+            'value',
+            100,
+            'condset = ? AND experiment = ?',
+            [$sqlcondition2, $eid]
+        );
 
         // Now execute hook again and check that it remains the same as first call.
         tool_abconfig_after_require_login();
@@ -424,7 +486,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals(get_config('auth_manual', 'expiration'), 'yes');
     }
 
-    public function test_session_multi_command() {
+    public function test_session_multi_command(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -440,19 +502,21 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('expiration', 'no', 'auth_manual');
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $record = array(
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $record = [
             'experiment' => $eid,
             'ipwhitelist' => '0.0.0.1',
             'commands' => '["CFG,passwordpolicy,1","forced_plugin_setting,auth_manual,expiration,yes"]',
             'condset' => 'set1',
             'value' => 100,
-        );
+        ];
         $DB->insert_record('tool_abconfig_condition', $record);
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set2', 'value' => 0));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["forced_plugin_setting,auth_manual,expiration,yes"]', 'condset' => 'set2', 'value' => 0]);
 
         // Execute the hook and test that the session config applied.
         tool_abconfig_after_require_login();
@@ -471,7 +535,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_session_multi_condition() {
+    public function test_session_multi_condition(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -487,13 +551,15 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('expiration', 'no', 'auth_manual');
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 0, 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 0, 'value' => 100]);
 
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 1, 'value' => 0));
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '0.0.0.1',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 1, 'value' => 0]);
 
         // Execute the hook, test only one condition set executed.
         tool_abconfig_after_require_login();
@@ -512,7 +578,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
         $this->assertEquals($CFG->passwordpolicy, 1);
     }
 
-    public function test_session_ip_whitelist() {
+    public function test_session_ip_whitelist(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -525,10 +591,12 @@ class tool_abconfig_lib_test extends advanced_testcase {
         set_config('passwordpolicy', 0);
 
         // Setup a valid experiment, and some conditions.
-        $eid = $DB->insert_record('tool_abconfig_experiment',
-            array('name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1));
-        $DB->insert_record('tool_abconfig_condition', array('experiment' => $eid, 'ipwhitelist' => '123.123.123.123',
-            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100));
+        $eid = $DB->insert_record(
+            'tool_abconfig_experiment',
+            ['name' => 'Experiment', 'shortname' => 'experiment', 'scope' => 'session', 'enabled' => 1]
+        );
+        $DB->insert_record('tool_abconfig_condition', ['experiment' => $eid, 'ipwhitelist' => '123.123.123.123',
+            'commands' => '["CFG,passwordpolicy,1"]', 'condset' => 'set1', 'value' => 100]);
 
         // Execute the hook and check that nothing was changed.
         tool_abconfig_after_require_login();
@@ -542,7 +610,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test no execute for device experiments.
      */
-    public function test_device_no_execute() {
+    public function test_device_no_execute(): void {
         $this->resetAfterTest(true);
         global $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -564,7 +632,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test changing config for device experiments.
      */
-    public function test_device_core_experiment() {
+    public function test_device_core_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -617,7 +685,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test changing plugin config for device experiments.
      */
-    public function test_device_plugin_experiment() {
+    public function test_device_plugin_experiment(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -671,7 +739,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test multiple commands for device experiments.
      */
-    public function test_device_multi_command() {
+    public function test_device_multi_command(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -732,7 +800,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test multiple conditions for device experiments.
      */
-    public function test_device_multi_condition() {
+    public function test_device_multi_condition(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -793,7 +861,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test ip allow list for device experiments.
      */
-    public function test_device_ip_whitelist() {
+    public function test_device_ip_whitelist(): void {
         $this->resetAfterTest(true);
         global $DB, $CFG;
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -835,7 +903,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test that the experiment is executed on a given user based on their id.
      */
-    public function test_condition_users_user_does_match_by_id() {
+    public function test_condition_users_user_does_match_by_id(): void {
         global $CFG;
         $this->resetAfterTest();
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
@@ -863,7 +931,7 @@ class tool_abconfig_lib_test extends advanced_testcase {
     /**
      * Test that the experiment is not executed on a user.
      */
-    public function test_condition_users_user_does_not_match_by_id() {
+    public function test_condition_users_user_does_not_match_by_id(): void {
         global $CFG;
         $this->resetAfterTest();
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';


### PR DESCRIPTION
Ran into exactly this:

> Hi both!
> 
> I have experienced similar issues with the plugin on my local dev box working on Moodle 4.5 upgrade for one of our clients. This work involved installing, testing and modifying bunch of different plugins. Some of them got callbacks replaced by hooks same way it happened for tool_abconfig.
> What I have observed that at some cases (i can't replicate it reliably yet) newly installed plugins have hooks registration missing, despite upgrade finished without errors. Purging cache, reinstalling plugins and etc didn't really help. The only way I was able to fix it is hacking into hook manager class and bypass using caches here https://github.com/moodle/moodle/blob/main/lib/classes/hook/manager.php#L345 So a list of hook is rebuilt. However. this in some cases broke tool_abconfig in a way it described as part of this issues.
> 
> I haven't had a chance to deep dive into this caching issues, but hope this information may help in your investigation.

https://github.com/catalyst/moodle-tool_abconfig/issues/73#issuecomment-2581472134

Closes #73. 